### PR TITLE
solves #4 – "nix expression for btrfs subvolume is not correct"

### DIFF
--- a/nixpart
+++ b/nixpart
@@ -67,6 +67,9 @@ def get_nixos_config(storage):
             fs = {}
             if label is not None:
                 fs['label'] = label
+            elif device.type == 'btrfs subvolume':
+                fs['label'] = device.volume.name
+                fs['options'] = device.format.mountopts
             else:
                 fs['device'] = path
             fs['fsType'] = device.format.type


### PR DESCRIPTION
This makes it possible to have a root subvolume in btrfs which is not
mounted as `/`.
